### PR TITLE
Add type to button to prevent form action

### DIFF
--- a/src/components/inclusive-dates/inclusive-dates.tsx
+++ b/src/components/inclusive-dates/inclusive-dates.tsx
@@ -511,6 +511,7 @@ export class InclusiveDates {
             aria-invalid={this.errorState}
           />
           <button
+            type="button"
             ref={(r) => (this.calendarButtonRef = r)}
             onClick={this.handleCalendarButtonClick}
             class={this.getClassName("calendar-button")}


### PR DESCRIPTION
Currently when using the element within a form the 'open calendar' button will
 call the form action, changing the type prevents that default behaviour.