### PR TITLE
Prevent unintentional form submit on quickbuttons click

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -440,6 +440,16 @@
               />
             </td>
           </tr>
+          <tr>
+            <td>
+              <code id="inline-label">inline</code><br />
+              <small>Keep the calendar visible; turn off hiding</small>
+            </td>
+            <td>
+              <input aria-labelledby="inline-label" id="inline" type="checkbox" value="inline"
+               />
+            </td>
+          </tr>
           </tbody>
         </table>
       </div>
@@ -1363,6 +1373,7 @@ defineCustomElements();</code></pre>
   const showYearStepperInput = document.getElementById("show-year-stepper");
   const startDateInput = document.getElementById("start-date");
   const valueInput = document.getElementById("value");
+  const inlineInput = document.getElementById("inline");
 
   function updateDemoCode() {
     demoCodeContainer.innerText = `${
@@ -1503,6 +1514,14 @@ defineCustomElements();</code></pre>
       datepicker.removeAttribute("start-date");
     }
 
+    updateDemoCode();
+  });
+
+  inlineInput.addEventListener("change", (event) => {
+    datepicker.setAttribute(
+      "inline",
+      String(event.target.checked)
+    );
     updateDemoCode();
   });
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -663,6 +663,14 @@ defineCustomElements();</code></pre>
             range selection is enabled.
           </td>
         </tr>
+        <tr>
+          <td><code>inline</code></td>
+          <td><code>boolean</code></td>
+          <td><code>false</code></td>
+          <td>
+            If true, the calendar will always be visible.
+          </td>
+        </tr>
         </tbody>
       </table>
     </div>

--- a/src/components/inclusive-dates-calendar/inclusive-dates-calendar.tsx
+++ b/src/components/inclusive-dates-calendar/inclusive-dates-calendar.tsx
@@ -97,6 +97,7 @@ export class InclusiveDatesCalendar {
   @Prop() previousYearButtonContent?: string;
   @Prop() minDate?: string;
   @Prop() maxDate?: string;
+  @Prop() inline?: boolean = false;
   @Prop() showClearButton?: boolean = false;
   @Prop() showMonthStepper?: boolean = true;
   @Prop() showTodayButton?: boolean = true;
@@ -443,7 +444,8 @@ export class InclusiveDatesCalendar {
         <div
           class={{
             [this.getClassName()]: true,
-            [`${this.getClassName()}--disabled`]: this.disabled
+            [`${this.getClassName()}--disabled`]: this.disabled,
+            [this.getClassName("inline")]: this.inline
           }}
         >
           <div class={this.getClassName("header")}>

--- a/src/components/inclusive-dates-modal/inclusive-dates-modal.tsx
+++ b/src/components/inclusive-dates-modal/inclusive-dates-modal.tsx
@@ -23,8 +23,9 @@ import { hideOthers } from "aria-hidden";
 export class InclusiveDatesModal {
   // Mandatory for accessibility
   @Prop() label!: string;
+  @Prop() inline?: boolean = false;
   @State() closing = false;
-  @State() showing = false;
+  @State() showing = this.inline || false;
   @Event() opened: EventEmitter;
   @Event() closed: EventEmitter;
 
@@ -37,6 +38,7 @@ export class InclusiveDatesModal {
    */
   @Method()
   async open() {
+    if (this.inline) return;
     this.showing = true;
     this.undo = hideOthers(this.el);
     this.opened.emit(undefined);
@@ -47,6 +49,7 @@ export class InclusiveDatesModal {
    */
   @Method()
   async close() {
+    if (this.inline) return;
     this.showing = false;
     this.closed.emit(undefined);
     this.undo();
@@ -83,7 +86,7 @@ export class InclusiveDatesModal {
           this.el = r;
         }}
       >
-        {this.showing && (
+        {!this.inline && this.showing && (
           <div
             part="body"
             onKeyDown={this.onKeyDown}
@@ -98,6 +101,11 @@ export class InclusiveDatesModal {
                 <slot />
               </div>
             </focus-trap>
+          </div>
+        )}
+        {this.inline && (
+          <div part="content">
+            <slot />
           </div>
         )}
       </Host>

--- a/src/components/inclusive-dates/inclusive-dates.tsx
+++ b/src/components/inclusive-dates/inclusive-dates.tsx
@@ -132,7 +132,6 @@ export class InclusiveDates {
   // Show or hide the quick buttons
   @Prop() showQuickButtons?: boolean = true;
 
-
   @State() internalValue: string | string[];
   @State() errorState: boolean = this.hasError;
   @State() disabledState: boolean = this.disabled;
@@ -573,28 +572,31 @@ export class InclusiveDates {
             disableDate={this.disableDate}
             minDate={this.minDate}
             maxDate={this.maxDate}
+            inline={this.inline}
           />
         </inclusive-dates-modal>
-        {this.showQuickButtons && this.quickButtons?.length > 0 && this.chronoSupportedLocale && (
-          <div
-            class={this.getClassName("quick-group")}
-            role="group"
-            aria-label="Quick selection"
-          >
-            {this.quickButtons.map((buttonText) => {
-              return (
-                <button
-                  class={this.getClassName("quick-button")}
-                  onClick={this.handleQuickButtonClick}
-                  disabled={this.disabledState}
-                  type="button"
-                >
-                  {buttonText}
-                </button>
-              );
-            })}
-          </div>
-        )}
+        {this.showQuickButtons &&
+          this.quickButtons?.length > 0 &&
+          this.chronoSupportedLocale && (
+            <div
+              class={this.getClassName("quick-group")}
+              role="group"
+              aria-label="Quick selection"
+            >
+              {this.quickButtons.map((buttonText) => {
+                return (
+                  <button
+                    class={this.getClassName("quick-button")}
+                    onClick={this.handleQuickButtonClick}
+                    disabled={this.disabledState}
+                    type="button"
+                  >
+                    {buttonText}
+                  </button>
+                );
+              })}
+            </div>
+          )}
 
         {this.errorState && (
           <div

--- a/src/components/inclusive-dates/inclusive-dates.tsx
+++ b/src/components/inclusive-dates/inclusive-dates.tsx
@@ -129,6 +129,9 @@ export class InclusiveDates {
     : ["Yesterday", "Today", "Tomorrow", "In 10 days"];
   // Text content for the today button in the calendar
   @Prop() todayButtonContent?: string;
+  // Show or hide the quick buttons
+  @Prop() showQuickButtons?: boolean = true;
+
 
   @State() internalValue: string | string[];
   @State() errorState: boolean = this.hasError;
@@ -572,7 +575,7 @@ export class InclusiveDates {
             maxDate={this.maxDate}
           />
         </inclusive-dates-modal>
-        {this.quickButtons?.length > 0 && this.chronoSupportedLocale && (
+        {this.showQuickButtons && this.quickButtons?.length > 0 && this.chronoSupportedLocale && (
           <div
             class={this.getClassName("quick-group")}
             role="group"

--- a/src/components/inclusive-dates/inclusive-dates.tsx
+++ b/src/components/inclusive-dates/inclusive-dates.tsx
@@ -35,6 +35,7 @@ export interface InclusiveDatesLabels {
   maxDateError?: string;
   minDateError?: string;
   rangeOutOfBoundsError?: string;
+  disabledDateError?: string;
   to?: string;
   startDate?: string;
 }
@@ -47,6 +48,7 @@ const defaultLabels: InclusiveDatesLabels = {
   minDateError: `Please fill in a date after `,
   maxDateError: `Please fill in a date before `,
   rangeOutOfBoundsError: `Please enter a valid range of dates`,
+  disabledDateError: `Please choose an available date`,
   to: "to",
   startDate: "Start date"
 };
@@ -92,6 +94,9 @@ export class InclusiveDates {
 
   @Prop() inclusiveDatesCalendarLabels?: InclusiveDatesCalendarLabels;
 
+  // Prevent hiding the calendar
+  @Prop() inline?: boolean = false;
+
   // Current error state of the input field
   @Prop({ mutable: true }) hasError?: boolean = false;
   // Text label for next month button
@@ -112,7 +117,8 @@ export class InclusiveDates {
   // Show or hide the keyboard hints
   @Prop() showKeyboardHint?: boolean = true;
   // Function to disable individual dates
-  @Prop() disableDate?: HTMLInclusiveDatesCalendarElement["disableDate"];
+  @Prop() disableDate?: HTMLInclusiveDatesCalendarElement["disableDate"] = () =>
+    false;
   // Component name used to generate CSS classes
   @Prop() elementClassName?: string = "inclusive-dates";
   // Which day that should start the week (0 is sunday, 1 is monday)
@@ -298,8 +304,13 @@ export class InclusiveDates {
         referenceDate: removeTimezoneOffset(new Date(this.referenceDate))
       });
       if (parsedDate && parsedDate.value instanceof Date) {
-        this.updateValue(parsedDate.value);
-        this.formatInput(true, false);
+        if (this.disableDate(parsedDate.value)) {
+          this.errorState = true;
+          this.errorMessage = this.inclusiveDatesLabels.disabledDateError;
+        } else {
+          this.updateValue(parsedDate.value);
+          this.formatInput(true, false);
+        }
       } else if (parsedDate) {
         this.errorState = true;
         this.internalValue = null;
@@ -510,15 +521,17 @@ export class InclusiveDates {
             aria-describedby={this.errorState ? `${this.id}-error` : undefined}
             aria-invalid={this.errorState}
           />
-          <button
-            type="button"
-            ref={(r) => (this.calendarButtonRef = r)}
-            onClick={this.handleCalendarButtonClick}
-            class={this.getClassName("calendar-button")}
-            disabled={this.disabledState}
-          >
-            {this.inclusiveDatesLabels.openCalendar}
-          </button>
+          {!this.inline && (
+            <button
+              type="button"
+              ref={(r) => (this.calendarButtonRef = r)}
+              onClick={this.handleCalendarButtonClick}
+              class={this.getClassName("calendar-button")}
+              disabled={this.disabledState}
+            >
+              {this.inclusiveDatesLabels.openCalendar}
+            </button>
+          )}
         </div>
         <inclusive-dates-modal
           label={this.inclusiveDatesLabels.calendar}
@@ -529,6 +542,7 @@ export class InclusiveDates {
           onClosed={() => {
             this.pickerRef.modalIsOpen = false;
           }}
+          inline={this.inline}
         >
           <inclusive-dates-calendar
             range={this.range}
@@ -553,6 +567,7 @@ export class InclusiveDates {
             showYearStepper={this.showYearStepper}
             showClearButton={this.showClearButton}
             showKeyboardHint={this.showKeyboardHint}
+            disableDate={this.disableDate}
             minDate={this.minDate}
             maxDate={this.maxDate}
           />

--- a/src/components/inclusive-dates/inclusive-dates.tsx
+++ b/src/components/inclusive-dates/inclusive-dates.tsx
@@ -569,6 +569,7 @@ export class InclusiveDates {
                   class={this.getClassName("quick-button")}
                   onClick={this.handleQuickButtonClick}
                   disabled={this.disabledState}
+                  type="button"
                 >
                   {buttonText}
                 </button>

--- a/src/themes/base.scss
+++ b/src/themes/base.scss
@@ -363,3 +363,7 @@ inclusive-dates *:focus-visible {
   color: var(--error-color);
   font-weight: 700;
 }
+
+.inclusive-dates-calendar__inline {
+  margin-top: 0.5em;
+}


### PR DESCRIPTION
When the datepicker is a child element of a form, adding type=“button” will prevent the form being submitted on click.