### PR TITLE
Allow to select date or range dates programatically with value attribute

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -192,7 +192,6 @@
             <td>
               <input
                 aria-labelledby="value-label"
-                disabled
                 id="value"
                 type="text"
               />
@@ -1413,6 +1412,11 @@ defineCustomElements();</code></pre>
 
   datepicker.addEventListener("selectDate", (event) => {
     valueInput.value = event.detail ? JSON.stringify(event.detail) : "";
+  });
+
+  valueInput.addEventListener("change", (event) => {
+    datepicker.setAttribute("value", event.target.value);
+    updateDemoCode();
   });
 
   idInput.addEventListener("change", (event) => {

--- a/src/components/inclusive-dates/inclusive-dates.tsx
+++ b/src/components/inclusive-dates/inclusive-dates.tsx
@@ -490,9 +490,20 @@ export class InclusiveDates {
   }
 
   @Watch("value")
-  watchValue() {
-    if (Boolean(this.value) && !this.isRangeValue(this.value)) {
-      this.internalValue = this.value as string;
+  watchValue(newValue) {
+    if (this.range) {
+      const parsedValue = JSON.parse(newValue.replace(/'/g, '"'));
+      this.internalValue = parsedValue;
+      this.pickerRef.value = parsedValue.map((date) =>
+        removeTimezoneOffset(new Date(date as string))
+      );
+    } else {
+      this.internalValue = newValue;
+      this.pickerRef.value = removeTimezoneOffset(new Date(newValue));
+    }
+    this.errorState = false;
+    if (document.activeElement !== this.inputRef) {
+      this.formatInput(true, false);
     }
   }
 


### PR DESCRIPTION
Hey there, thanks for the project!

We're integrating this element to have an accessible datepicker. However, we need to be able to have a date selected from the beginning.

The main use case is an edit form, where there's already a date previously selected and we want to allow to select another one. The selected date must be clearly marked, the `start-date` attribute isn't enough.

Another scenario is to support a change coming from the server, for example, making column filters in a table, filtering by date. In our case we use morphing for most of the inputs and it was easy to prevent the algorithm from touching the element so that it doesn't lose state. But still, ideally it should be resistant to changing the value attribute so that integration can be simpler.

I also thought about converting the private method `updateValue` to public, but I think that being able to define it from the HTML or JavaScript indistinctly is more consistent.

There's the possibility of using the public method `parseDate`, but it doesn't support ranges. If it's useful for that method to accept them too, I could do it in another PR.

Now you can initialize the element in the following 2 ways, with the selected date or with the selected date range:

```html
<inclusive-dates id="datepicker" value="2024-01-01"></inclusive-dates>
<inclusive-dates id="range-datepicker" range="true" value="['2024-01-01', '2024-01-05']"></inclusive-dates>
```

It can also be seen in action on the demo page.